### PR TITLE
use cargo ndk to build android for different targets

### DIFF
--- a/rust.sh
+++ b/rust.sh
@@ -6,13 +6,20 @@ function current() {
 
     ## check now os.
 }
+function init_android() {
+    cargo install cargo-ndk
+    
+    rustup target add \
+    aarch64-linux-android \
+    armv7-linux-androideabi \
+    x86_64-linux-android \
+    i686-linux-android
 
+}
 #### Android ####
 function android() {
-    ## build library
-    cargo build --release --target=aarch64-linux-android
-    #cargo build --release --target=i686-linux-android
-    #cargo build --release --target=armv7-linux-androideabi
+    
+    cargo ndk -t armeabi-v7a -t arm64-v8a -t x86 -t x86_64 -o ./jniLibs build --release 
 
     ## crate & link to android directory
     mkdir -p core/android/src/main/jniLibs/arm64-v8a
@@ -20,7 +27,7 @@ function android() {
     mkdir -p core/android/src/main/jniLibs/x86
     echo 'android jniLibs directory build ok!'
 
-    cp target/aarch64-linux-android/release/libesse.so core/android/src/main/jniLibs/arm64-v8a/libesse.so
+    cp -rf ./jniLibs/ core/android/src/main/jniLibs/
 
     echo 'Flutter: Android dynamic library is ok!'
 }
@@ -81,3 +88,4 @@ else
     echo "Now is building: $1"
     $1
 fi
+


### PR DESCRIPTION
Have errors build android: needs to install ndk  separately  and configure path.
 switch to cargo ndk should be easier for us to builds 

./rust.sh init_android  (init android targets)
./rust.sh android 